### PR TITLE
Add support for sum and count aggregates

### DIFF
--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/AtomList.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/AtomList.kt
@@ -28,7 +28,12 @@ inline fun AtomList.forEachIndexed(f: (Int, Atom) -> Unit) {
 
 operator fun AtomList.plus(other: AtomList): AtomList = (map { it } + other.map { it }).asAtomList()
 
-inline fun <T> AtomList.map(f: (Atom) -> T): List<T> = buildList { this@map.forEach { add(f(it)) } }
+inline fun <T, C : MutableCollection<in T>> AtomList.mapTo(destination: C, f: (Atom) -> T): C {
+  forEach { destination.add(f(it)) }
+  return destination
+}
+
+inline fun <T> AtomList.map(f: (Atom) -> T): List<T> = mapTo(ArrayList(size), f)
 
 fun AtomList.toList(): List<Atom> = map { it }
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/Domain.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/Domain.kt
@@ -3,6 +3,9 @@ package io.github.alexandrepiveteau.datalog.core
 /** An interface representing information about the domain of the constants in the program. */
 interface Domain {
 
+  /** Returns the sum of the two [Atom]s. */
+  fun sum(a: Atom, b: Atom): Atom
+
   /** Returns the maximum of the two [Atom]s. */
   fun max(a: Atom, b: Atom): Atom
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/Domain.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/Domain.kt
@@ -3,6 +3,9 @@ package io.github.alexandrepiveteau.datalog.core
 /** An interface representing information about the domain of the constants in the program. */
 interface Domain {
 
+  /** Returns an [Atom] representing the unit constant. */
+  fun unit(): Atom
+
   /** Returns the sum of the two [Atom]s. */
   fun sum(a: Atom, b: Atom): Atom
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/RuleBuilder.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/RuleBuilder.kt
@@ -9,6 +9,9 @@ interface RuleBuilder {
   /** An enumeration representing the different kinds of aggregates available. */
   enum class Aggregate(private val merge: Domain.(Atom, Atom) -> Atom) {
 
+    /** Returns the sum. */
+    Sum(Domain::sum),
+
     /** Returns the minimum value. */
     Min(Domain::min),
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/DatalogRuleBuilder.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/DatalogRuleBuilder.kt
@@ -19,7 +19,7 @@ internal class DatalogRuleBuilder : RuleBuilder {
   private data class StoredAggregate(
       val operator: RuleBuilder.Aggregate,
       val same: AtomList,
-      val column: Atom,
+      val columns: AtomList,
       val result: Atom,
   )
 
@@ -40,10 +40,10 @@ internal class DatalogRuleBuilder : RuleBuilder {
   override fun aggregate(
       operator: RuleBuilder.Aggregate,
       same: AtomList,
-      column: Atom,
+      columns: AtomList,
       result: Atom,
   ) {
-    aggregates.add(StoredAggregate(operator, same, column, result))
+    aggregates.add(StoredAggregate(operator, same, columns, result))
   }
 
   /**
@@ -87,7 +87,7 @@ internal class DatalogRuleBuilder : RuleBuilder {
         clause = clause,
         operator = aggregate.operator,
         same = aggregate.same,
-        column = aggregate.column,
+        columns = aggregate.columns,
         result = aggregate.result,
     )
   }

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/Evaluation.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/Evaluation.kt
@@ -104,13 +104,14 @@ private fun Context.evalAggregationRule(
           else -> AggregationColumn.Column(Constant(atom))
         }
       }
-  val same = rule.same.map { Index(rule.clause.atoms.indexOf(it)) }.toSet()
+  val same = rule.same.mapTo(mutableSetOf()) { Index(rule.clause.atoms.indexOf(it)) }
+  val indices = rule.columns.mapTo(mutableSetOf()) { Index(rule.clause.atoms.indexOf(it)) }
   return negated.aggregate(
       projection = projection,
       same = same,
       domain = domain,
       aggregate = rule.operator,
-      index = Index(rule.clause.atoms.indexOf(rule.column)),
+      indices = indices,
   )
 }
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/Rule.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/Rule.kt
@@ -64,8 +64,8 @@ internal data class Clause(
  * @param clause the [Clause] that should be used to derive some new facts.
  * @param operator the [RuleBuilder.Aggregate] operator that should be used to aggregate the [same]
  *   atoms.
- * @param same the [AtomList] that should be used to aggregate the [column] atoms.
- * @param column the variable [Atom] that should be aggregated.
+ * @param same the [AtomList] that should be used to aggregate the [columns] atoms.
+ * @param columns the variable [Atom] that should be aggregated.
  * @param result the variable [Atom] that should be used to store the result of the aggregation.
  */
 internal data class AggregationRule(
@@ -74,7 +74,7 @@ internal data class AggregationRule(
     val clause: Clause,
     val operator: RuleBuilder.Aggregate,
     val same: AtomList,
-    val column: Atom,
+    val columns: AtomList,
     val result: Atom,
 ) : Rule {
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/Column.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/Column.kt
@@ -7,7 +7,7 @@ import io.github.alexandrepiveteau.datalog.core.Atom
  *
  * @see Relation.project
  */
-internal sealed interface Column {
+sealed interface Column {
 
   /** Projects a constant value for all rows. */
   data class Constant(val value: Atom) : Column

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/Relation.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/Relation.kt
@@ -213,7 +213,7 @@ internal fun Relation.aggregate(
     // rows will eventually map to the same value, and the aggregate function will be applied to
     // merge them.
     val result = mutableMapOf<AtomList, AtomList>()
-    forEach { atom ->
+    distinct().forEach { atom ->
       val key = same.map { atom[it.index] }.asAtomList()
       val existing = result[key]
       val value = projection.map { atom.value(it, index) }.asAtomList()

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Aggregate.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Aggregate.kt
@@ -8,12 +8,12 @@ import io.github.alexandrepiveteau.datalog.core.RuleBuilder.Aggregate as CoreAgg
  * @param T the type of the elements in the relations.
  * @param aggregate the aggregation function to use.
  * @param same the list of variables that must be equal.
- * @param column the column to aggregate.
+ * @param columns the columns to aggregate.
  * @param result the result of the aggregation.
  */
 data class Aggregate<out T>(
     val aggregate: CoreAggregate,
-    val same: List<Variable<T>>,
-    val column: Variable<T>,
+    val same: Iterable<Variable<T>>,
+    val columns: Iterable<Variable<T>>,
     val result: Variable<T>,
 )

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/DatalogScope.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/DatalogScope.kt
@@ -42,17 +42,32 @@ interface DatalogScope<T> {
 
   // Aggregation functions.
 
-  /** Returns an [Aggregate] to compute the total value of a column. */
-  fun sum(same: Iterable<Variable<T>>, column: Variable<T>, result: Variable<T>): Aggregate<T> =
-      Aggregate(RuleBuilder.Aggregate.Sum, same.toList(), column, result)
+  /** Returns an [Aggregate] to compute the number of rows in a relation. */
+  fun count(
+      same: Iterable<Variable<T>>,
+      result: Variable<T>,
+  ): Aggregate<T> = Aggregate(RuleBuilder.Aggregate.Count, same, emptySet(), result)
 
-  /** Returns an [Aggregate] to compute the maximum value of a column. */
-  fun max(same: Iterable<Variable<T>>, column: Variable<T>, result: Variable<T>): Aggregate<T> =
-      Aggregate(RuleBuilder.Aggregate.Max, same.toList(), column, result)
+  /** Returns an [Aggregate] to compute the total value of some columns. */
+  fun sum(
+      same: Iterable<Variable<T>>,
+      columns: Iterable<Variable<T>>,
+      result: Variable<T>,
+  ): Aggregate<T> = Aggregate(RuleBuilder.Aggregate.Sum, same, columns, result)
 
-  /** Returns an [Aggregate] to compute the minimum value of a column. */
-  fun min(same: Iterable<Variable<T>>, column: Variable<T>, result: Variable<T>): Aggregate<T> =
-      Aggregate(RuleBuilder.Aggregate.Min, same.toList(), column, result)
+  /** Returns an [Aggregate] to compute the maximum value of some columns. */
+  fun max(
+      same: Iterable<Variable<T>>,
+      columns: Iterable<Variable<T>>,
+      result: Variable<T>,
+  ): Aggregate<T> = Aggregate(RuleBuilder.Aggregate.Max, same, columns, result)
+
+  /** Returns an [Aggregate] to compute the minimum value of some columns. */
+  fun min(
+      same: Iterable<Variable<T>>,
+      columns: Iterable<Variable<T>>,
+      result: Variable<T>,
+  ): Aggregate<T> = Aggregate(RuleBuilder.Aggregate.Min, same, columns, result)
 
   // Terms operators.
   operator fun Term<T>.plus(term: Term<T>): Terms<T> = Terms(setOf(this, term))

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/DatalogScope.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/DatalogScope.kt
@@ -8,7 +8,7 @@ import io.github.alexandrepiveteau.datalog.core.RuleBuilder
  *
  * @param T the type of the elements in the relations. Must be comparable.
  */
-interface DatalogScope<T : Comparable<T>> {
+interface DatalogScope<T> {
 
   /**
    * Returns some [Terms] which are guaranteed to be empty. This is useful when we want to create a
@@ -41,6 +41,10 @@ interface DatalogScope<T : Comparable<T>> {
   operator fun Term<T>.not() = copy(negated = !negated)
 
   // Aggregation functions.
+
+  /** Returns an [Aggregate] to compute the total value of a column. */
+  fun sum(same: Iterable<Variable<T>>, column: Variable<T>, result: Variable<T>): Aggregate<T> =
+      Aggregate(RuleBuilder.Aggregate.Sum, same.toList(), column, result)
 
   /** Returns an [Aggregate] to compute the maximum value of a column. */
   fun max(same: Iterable<Variable<T>>, column: Variable<T>, result: Variable<T>): Aggregate<T> =

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Domain.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Domain.kt
@@ -9,6 +9,9 @@ import io.github.alexandrepiveteau.datalog.dsl.domains.IntDomain
  */
 interface Domain<T> {
 
+  /** Returns a [T] representing the unit constant. */
+  fun unit(): T
+
   /** Returns the sum of the two [T]s. */
   fun sum(a: T, b: T): T
 

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Domain.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Domain.kt
@@ -1,0 +1,26 @@
+package io.github.alexandrepiveteau.datalog.dsl
+
+import io.github.alexandrepiveteau.datalog.dsl.domains.IntDomain
+
+/**
+ * An interface representing information about the domain of constants in the program.
+ *
+ * @param T the type of the constants in the domain.
+ */
+interface Domain<T> {
+
+  /** Returns the sum of the two [T]s. */
+  fun sum(a: T, b: T): T
+
+  /** Returns the maximum value of the two [T]s. */
+  fun max(a: T, b: T): T
+
+  /** Returns the minimum value of the two [T]s. */
+  fun min(a: T, b: T): T
+
+  companion object {
+
+    /** Returns a [Domain] for [Int] values. */
+    fun int(): Domain<Int> = IntDomain
+  }
+}

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Dsl.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/Dsl.kt
@@ -52,6 +52,8 @@ private class ActualDomain<T>(
     private val translation: Translation<T, CoreAtom>,
 ) : CoreDomain {
 
+  override fun unit(): CoreAtom = translation.getValue(domain.unit())
+
   override fun sum(
       a: CoreAtom,
       b: CoreAtom,
@@ -109,7 +111,7 @@ private class Datalog<T>(domain: Domain<T>, algorithm: Algorithm) : DatalogScope
           aggregate(
               a.aggregate,
               a.same.map { it.translate() }.asAtomList(),
-              a.column.translate(),
+              a.columns.map { it.translate() }.asAtomList(),
               a.result.translate(),
           )
         }

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/domains/IntDomain.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/domains/IntDomain.kt
@@ -4,6 +4,7 @@ import io.github.alexandrepiveteau.datalog.dsl.Domain
 
 /** An implementation of [Domain] for [Int] values. */
 internal object IntDomain : Domain<Int> {
+  override fun unit(): Int = 1
   override fun sum(a: Int, b: Int): Int = a + b
   override fun max(a: Int, b: Int): Int = maxOf(a, b)
   override fun min(a: Int, b: Int): Int = minOf(a, b)

--- a/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/domains/IntDomain.kt
+++ b/src/main/kotlin/io/github/alexandrepiveteau/datalog/dsl/domains/IntDomain.kt
@@ -1,0 +1,10 @@
+package io.github.alexandrepiveteau.datalog.dsl.domains
+
+import io.github.alexandrepiveteau.datalog.dsl.Domain
+
+/** An implementation of [Domain] for [Int] values. */
+internal object IntDomain : Domain<Int> {
+  override fun sum(a: Int, b: Int): Int = a + b
+  override fun max(a: Int, b: Int): Int = maxOf(a, b)
+  override fun min(a: Int, b: Int): Int = minOf(a, b)
+}

--- a/src/test/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/IntDomain.kt
+++ b/src/test/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/IntDomain.kt
@@ -16,6 +16,7 @@ internal object IntDomain : Domain {
     return atom.backing
   }
 
+  override fun unit(): Atom = get(1)
   override fun sum(a: Atom, b: Atom): Atom = get(get(a) + get(b))
   override fun max(a: Atom, b: Atom): Atom = get(maxOf(get(a), get(b)))
   override fun min(a: Atom, b: Atom): Atom = get(minOf(get(a), get(b)))

--- a/src/test/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/IntDomain.kt
+++ b/src/test/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/IntDomain.kt
@@ -16,6 +16,7 @@ internal object IntDomain : Domain {
     return atom.backing
   }
 
+  override fun sum(a: Atom, b: Atom): Atom = get(get(a) + get(b))
   override fun max(a: Atom, b: Atom): Atom = get(maxOf(get(a), get(b)))
   override fun min(a: Atom, b: Atom): Atom = get(minOf(get(a), get(b)))
 }

--- a/src/test/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/RelationTests.kt
+++ b/src/test/kotlin/io/github/alexandrepiveteau/datalog/core/interpreter/algebra/RelationTests.kt
@@ -17,7 +17,7 @@ class RelationTests {
             same = emptySet(),
             domain = IntDomain,
             aggregate = RuleBuilder.Aggregate.Max,
-            index = Index(0),
+            indices = emptySet(),
         )
 
     assertEquals(0, aggregate.arity)

--- a/src/test/kotlin/io/github/alexandrepiveteau/datalog/dsl/AggregateTests.kt
+++ b/src/test/kotlin/io/github/alexandrepiveteau/datalog/dsl/AggregateTests.kt
@@ -12,7 +12,7 @@ class AggregateTests {
       program {
         val (p) = predicates()
         val (x, v, s) = variables()
-        p(x, s) += p(x, v) + max(listOf(x), v, result = s)
+        p(x, s) += p(x, v) + max(setOf(x), setOf(v), result = s)
 
         expect(p, 2) { /* Fails */}
       }
@@ -28,8 +28,8 @@ class AggregateTests {
     q(1, 2, 3) += empty
     q(2, 1, 4) += empty
 
-    p(x, s) += q(x, y, v) + max(listOf(x), v, result = s)
-    r(y, s) += q(x, y, v) + max(listOf(y), v, result = s)
+    p(x, s) += q(x, y, v) + max(setOf(x), setOf(v), result = s)
+    r(y, s) += q(x, y, v) + max(setOf(y), setOf(v), result = s)
 
     expect(p, arity = 2) {
       add(listOf(1, 3))
@@ -50,8 +50,8 @@ class AggregateTests {
     q(1, 2, 3) += empty
     q(2, 1, 4) += empty
 
-    p(x, s) += q(x, y, v) + min(listOf(x), v, result = s)
-    r(y, s) += q(x, y, v) + min(listOf(y), v, result = s)
+    p(x, s) += q(x, y, v) + min(setOf(x), setOf(v), result = s)
+    r(y, s) += q(x, y, v) + min(setOf(y), setOf(v), result = s)
 
     expect(p, arity = 2) {
       add(listOf(1, 2))
@@ -73,8 +73,41 @@ class AggregateTests {
     p(2) += empty
     p(3) += empty
 
-    r(s) += p(v) + sum(listOf(), v, result = s)
+    r(s) += p(v) + sum(emptySet(), setOf(v), result = s)
 
     expect(r, arity = 1) { add(listOf(6)) }
+  }
+
+  @Test
+  fun `count items without duplicates`() = program {
+    constants(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val (p, r) = predicates()
+    val (v, s) = variables()
+
+    p(1) += empty
+    p(2) += empty
+    p(3) += empty
+
+    r(s) += p(v) + count(emptySet(), result = s)
+
+    expect(r, arity = 1) { add(listOf(3)) }
+  }
+
+  @Test
+  fun `count items with duplicates returns distinct count`() = program {
+    constants(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val (p, r) = predicates()
+    val (v, s) = variables()
+
+    p(1) += empty
+    p(2) += empty
+    p(2) += empty
+    p(3) += empty
+    p(3) += empty
+    p(3) += empty
+
+    r(s) += p(v) + count(emptySet(), result = s)
+
+    expect(r, arity = 1) { add(listOf(3)) }
   }
 }

--- a/src/test/kotlin/io/github/alexandrepiveteau/datalog/dsl/AggregateTests.kt
+++ b/src/test/kotlin/io/github/alexandrepiveteau/datalog/dsl/AggregateTests.kt
@@ -62,4 +62,19 @@ class AggregateTests {
       add(listOf(2, 3))
     }
   }
+
+  @Test
+  fun `sum from column`() = program {
+    constants(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val (p, r) = predicates()
+    val (v, s) = variables()
+
+    p(1) += empty
+    p(2) += empty
+    p(3) += empty
+
+    r(s) += p(v) + sum(listOf(), v, result = s)
+
+    expect(r, arity = 1) { add(listOf(6)) }
+  }
 }

--- a/src/test/kotlin/io/github/alexandrepiveteau/datalog/dsl/Program.kt
+++ b/src/test/kotlin/io/github/alexandrepiveteau/datalog/dsl/Program.kt
@@ -41,6 +41,6 @@ fun DatalogScope<Int>.expect(
  */
 fun program(scope: DatalogScope<Int>.() -> Unit) {
   for (algorithm in Algorithm.values()) {
-    datalog(algorithm, scope)
+    datalog(Domain.int(), algorithm, scope)
   }
 }


### PR DESCRIPTION
This PR adds support for the following features:

- [x] `sum()` aggregate, to indicate the total of the values;
- [x] `count()` aggregate, to indicate the number of distinct rows;
- [x] multi-column aggregates, so `min`, `max`, and `sum` can be taken over multiple columns and aggregated at once.